### PR TITLE
extern crate ⇒ use

### DIFF
--- a/src/events/console/mod.rs
+++ b/src/events/console/mod.rs
@@ -2,6 +2,8 @@
 use crate::CONSOLE;
 
 use clipboard::{ClipboardContext, ClipboardProvider};
+use lazy_static::lazy_static;
+use log::debug;
 
 mod commands;
 

--- a/src/events/select.rs
+++ b/src/events/select.rs
@@ -2,6 +2,7 @@
 use super::prelude::*;
 use crate::state::Follow;
 use glifparser::{Handle, WhichHandle};
+use log::debug;
 
 /// Get indexes stored by clicked_point_or_handle and move the points they refer to around.
 pub fn mouse_moved<T>(position: PhysicalPosition<f64>, v: &RefCell<state::State<T>>) -> bool {

--- a/src/events/vws.rs
+++ b/src/events/vws.rs
@@ -2,6 +2,7 @@ use super::prelude::*;
 use crate::io::{load_glif, save_glif};
 use crate::state::Follow;
 use glifparser::{Handle, WhichHandle};
+use log::debug;
 use skulpin::skia_safe::{Canvas, Paint, PaintStyle, Path as SkiaPath};
 use MFEKMath::variable_width_stroking::{generate_vws_lib, InterpolationType};
 use MFEKMath::{

--- a/src/events/zoom.rs
+++ b/src/events/zoom.rs
@@ -1,6 +1,8 @@
 // Zoom
 use super::prelude::*;
 
+use log::debug;
+
 pub fn zoom_in_factor<T>(_factor: f32, v: &RefCell<state::State<T>>) -> f32 {
     v.borrow().factor + SCALE_FACTOR
 }

--- a/src/filedialog.rs
+++ b/src/filedialog.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-extern crate nfd;
+use nfd;
 
 pub fn filename_or_panic(
     filename: &Option<String>,

--- a/src/imgui/support.rs
+++ b/src/imgui/support.rs
@@ -5,6 +5,7 @@
 use crate::imgui_rs;
 use crate::system_fonts;
 use imgui_winit_support;
+use log::debug;
 
 use crate::imgui;
 use crate::imgui_rs::sys as imgui_sys;

--- a/src/io.rs
+++ b/src/io.rs
@@ -4,6 +4,7 @@ use crate::events;
 use crate::state;
 use crate::STATE;
 use glifparser::Glif;
+use log::{debug, error};
 use std::cell::RefCell;
 use std::env;
 use std::fs;

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -1,3 +1,4 @@
+use log::error;
 use mfek_ipc::{self, IPCInfo};
 
 use crate::renderer::{Guideline, GuidelineType};

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,31 +11,29 @@
 )]
 
 // Cargo.toml comments say what crates are used for what.
+use backtrace;
+use clap;
+use colored;
+use derive_more;
+use enum_iterator;
 #[macro_use]
-extern crate lazy_static;
-extern crate backtrace;
-extern crate clap;
-extern crate colored;
-extern crate derive_more;
-extern crate enum_iterator;
+use log::debug;
+use env_logger;
 #[macro_use]
-extern crate log;
-extern crate env_logger;
-#[macro_use]
-extern crate git_version; // for util::parse_args
-extern crate font_kit;
+use git_version; // for util::parse_args
+use font_kit;
 
-extern crate imgui_winit_support;
-extern crate skulpin;
-extern crate skulpin_plugin_imgui;
+use imgui_winit_support;
+use skulpin;
+use skulpin_plugin_imgui;
 
-extern crate clipboard;
-extern crate regex;
+use clipboard;
+use regex;
 
 // Our crates
-extern crate glifparser;
-extern crate mfek_ipc;
-extern crate xmltree;
+use glifparser;
+use mfek_ipc;
+use xmltree;
 
 use crate::winit::dpi::LogicalSize;
 use crate::winit::event::{ElementState, Event, KeyboardInput, VirtualKeyCode, WindowEvent};

--- a/src/renderer/console.rs
+++ b/src/renderer/console.rs
@@ -3,6 +3,9 @@
 //! output of a single Command.) That's because this is a *Renderer Console*, not supposed to
 //! represent the Console itself, but rather just what we show the user on the screen. We output to
 //! the normal stdout as well, that's the persistent stdout.
+
+use lazy_static::lazy_static;
+
 pub struct Console {
     pub stdin: String,
     pub stdout: String,

--- a/src/renderer/constants.rs
+++ b/src/renderer/constants.rs
@@ -1,5 +1,6 @@
 //! Constants. This file should eventually become a config dotfile loaded & reloaded dynamically.
 //! See issue #7 (GitHub).
+use lazy_static::lazy_static;
 
 /* Sizes */
 pub static OUTLINE_STROKE_THICKNESS: f32 = 1.5 * PEN_SIZE;

--- a/src/system_fonts.rs
+++ b/src/system_fonts.rs
@@ -1,3 +1,5 @@
+use lazy_static::lazy_static;
+
 use crate::renderer::constants::CONSOLE_FONTS;
 
 use font_kit::{

--- a/src/util/argparser.rs
+++ b/src/util/argparser.rs
@@ -1,4 +1,5 @@
 // Argument parser
+use git_version::git_version;
 
 use clap; //argparse lib
 

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -10,6 +10,7 @@ use std::panic::set_hook;
 
 use backtrace::Backtrace;
 use colored::Colorize;
+use lazy_static::lazy_static;
 
 lazy_static! {
     pub static ref DEBUG: bool = option_env!("DEBUG").is_some();
@@ -49,7 +50,7 @@ pub fn set_panic_hook() {
 // This prevents debug!() etc from producing mojibake. Yes, really, this is the best solution. :-|
 #[cfg(target_family = "windows")]
 pub fn set_codepage_utf8() {
-    extern crate winapi;
+    use winapi;
     unsafe {
         debug_assert!(winapi::um::wincon::SetConsoleOutputCP(winapi::um::winnls::CP_UTF8) == 1);
     }


### PR DESCRIPTION
The `extern crate` syntax is deprecated as of Rust 1.30 (Oct 25, 2018).

That was the syntax I learned under, but the new syntax is better. The new syntax, however, doesn't carry macros imported in the `main.rs` to all modules, you have to manually `use` them like other functions. So, I've added those where called for.