### PR TITLE
Add flag so ‘cargo’ automatically uses nightly

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,1 @@
+nightly


### PR DESCRIPTION
See comments in #97

Note this is actually the *legacy* format for this file. There is a newer TOML based file with a few more features like specifying the actual minimum date for nightlies, but I have found that while `cargo` itself handles the new format fine (of course) lots of other ecosystem tooling isn't paying attention yet. Specifically some CI runners I like to use don't regard it yet.