### PR TITLE
More macOS high dpi fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,6 @@ Note: This is a basic list to get you started. A complete list can be found in `
 
 MFEKglif is still beta-quality software, and a numbered release hasn't been made yet. Before 1.0 is out, though, you can test it out with the artifacts function in GitHub. Go to [«Actions»](https://github.com/MFEK/glif/actions), choose a commit, and download the artifact for your OS. Three are uploaded: MFEKglif-linux, MFEKglif-windows, and MFEKglif-macos (not notarized).
 
-### Mac users
-
-MFEKglif does compile and run on M1 Macintoshes. However, if you have a “Retina” display, scaling/mouse events may be broken. A user tried some patches to fix this, but none worked. Until it can be fixed, please use e.g. [Display Menu](https://apps.apple.com/us/app/display-menu/id549083868?mt=12) to use 1:1 SDL pixels.
-
 ## Building
 
 ### Mac users

--- a/src/user_interface/gui/prompts.rs
+++ b/src/user_interface/gui/prompts.rs
@@ -80,7 +80,10 @@ pub fn build_and_check_prompts(v: &mut Editor, i: &mut Interface, ui: &mut imgui
                 .flags(imgui::WindowFlags::NO_RESIZE | imgui::WindowFlags::NO_COLLAPSE)
                 .position_pivot([0.5, 0.5])
                 .position(
-                    [(i.viewport.winsize.0 / 2.), (i.viewport.winsize.1 / 2.)],
+                    [
+                        (i.viewport.winsize.0 / 2.) * i.os_dpi(),
+                        (i.viewport.winsize.1 / 2.) * i.os_dpi(),
+                    ],
                     imgui::Condition::Always,
                 )
                 .size(
@@ -118,7 +121,10 @@ pub fn build_and_check_prompts(v: &mut Editor, i: &mut Interface, ui: &mut imgui
                 .flags(imgui::WindowFlags::NO_RESIZE | imgui::WindowFlags::NO_COLLAPSE)
                 .position_pivot([0.5, 0.5])
                 .position(
-                    [(i.viewport.winsize.0 / 2.), (i.viewport.winsize.1 / 2.)],
+                    [
+                        (i.viewport.winsize.0 / 2.) * i.os_dpi(),
+                        (i.viewport.winsize.1 / 2.) * i.os_dpi(),
+                    ],
                     imgui::Condition::Always,
                 )
                 .size(
@@ -157,7 +163,10 @@ pub fn build_and_check_prompts(v: &mut Editor, i: &mut Interface, ui: &mut imgui
                 .flags(imgui::WindowFlags::NO_RESIZE | imgui::WindowFlags::NO_COLLAPSE)
                 .position_pivot([0.5, 0.5])
                 .position(
-                    [(i.viewport.winsize.0 / 2.), (i.viewport.winsize.1 / 2.)],
+                    [
+                        (i.viewport.winsize.0 / 2.) * i.os_dpi(),
+                        (i.viewport.winsize.1 / 2.) * i.os_dpi(),
+                    ],
                     imgui::Condition::Always,
                 )
                 .size(

--- a/src/user_interface/mod.rs
+++ b/src/user_interface/mod.rs
@@ -91,10 +91,11 @@ impl Interface {
     }
 
     pub fn get_tools_dialog_rect(&self) -> (f32, f32, f32, f32) {
-        let offset_y = (self.viewport.winsize.1 as f32 - (LAYERBOX_HEIGHT * 2.)) / 3.;
+        let offset_y =
+            (self.viewport.winsize.1 as f32 * self.sdl_dpi - (LAYERBOX_HEIGHT * 2.)) / 3.;
         (
-            self.viewport.winsize.0 as f32 - (LAYERBOX_WIDTH) - (TOOLBOX_OFFSET_X),
-            self.viewport.winsize.1 as f32
+            self.viewport.winsize.0 as f32 * self.sdl_dpi - (LAYERBOX_WIDTH) - (TOOLBOX_OFFSET_X),
+            self.viewport.winsize.1 as f32 * self.sdl_dpi
                 - (LAYERBOX_HEIGHT * 2.)
                 - (TOOLBOX_OFFSET_Y * 2.)
                 - offset_y,


### PR DESCRIPTION
This should solve the last of the issues with high dpi on macOS. Interestingly, in prompts.rs, the solution was already applied to one of the prompts and it was simply not carried over to the other 3 prompt types until now.