### PR TITLE
[`Editor` type] `with_active_layer` family of functions → `get_active_layer` family of functions

### DIFF
--- a/src/editor/images.rs
+++ b/src/editor/images.rs
@@ -105,10 +105,9 @@ impl Editor {
                                // a pop up box or something should do but I'm not super concerned about this at the moment
         };
 
-        self.with_active_layer_mut(|layer| {
-            // this clone is a bit rough as this could be a -lot- of data
-            layer.images.push((image.clone(), image.matrix().into()))
-        });
+        let matrix = image.matrix();
+        self.get_active_layer_mut().images.push((image, matrix.into()));
+
         self.recache_images();
     }
 }

--- a/src/editor/macros.rs
+++ b/src/editor/macros.rs
@@ -1,35 +1,35 @@
 /// Shorthand macros for use inside editor.with() closures.
 #[macro_export]
 macro_rules! get_contour {
-    ($v:ident, $idx:expr) => {
+    ($v:expr, $idx:expr) => {
         $v.outline[$idx].inner
     };
 }
 
 #[macro_export]
 macro_rules! get_contour_mut {
-    ($v:ident, $idx:expr) => {
+    ($v:expr, $idx:expr) => {
         &mut $v.outline[$idx].inner
     };
 }
 
 #[macro_export]
 macro_rules! get_contour_len {
-    ($v:ident, $idx:expr) => {
+    ($v:expr, $idx:expr) => {
         $v.outline[$idx].inner.len()
     };
 }
 
 #[macro_export]
 macro_rules! get_contour_type {
-    ($v:ident, $idx:expr) => {
+    ($v:expr, $idx:expr) => {
         $v.outline[$idx].inner.first().unwrap().ptype
     };
 }
 
 #[macro_export]
 macro_rules! get_point {
-    ($v:ident, $cidx:expr, $pidx:expr) => {
+    ($v:expr, $cidx:expr, $pidx:expr) => {
         $v.outline[$cidx].inner[$pidx]
     };
 }

--- a/src/editor/selection.rs
+++ b/src/editor/selection.rs
@@ -190,7 +190,8 @@ impl Editor {
         self.point_idx = None;
         self.selected.clear();
 
-        let new_selected = self.with_active_layer_mut(|layer| {
+        let new_selected = {
+            let layer = self.get_active_layer_mut();
             if let Some(mpos) = position {
                 let comb = clipboard.outline.to_skia_paths(None).combined();
                 let b = comb.bounds();
@@ -225,7 +226,7 @@ impl Editor {
             }
 
             new_selected
-        });
+        };
 
         self.selected.extend(new_selected);
 
@@ -281,8 +282,8 @@ impl Editor {
                 }
             }
         }
-
-        self.with_active_layer_mut(|layer| layer.outline = new_outline.clone());
+        
+        self.get_active_layer_mut().outline = new_outline;
 
         self.contour_idx = None;
         self.point_idx = None;
@@ -294,7 +295,7 @@ impl Editor {
     pub fn build_selection_bounding_box(&self) -> Rect {
         let mut points = vec![];
         for (ci, pi) in &self.selected {
-            let point = self.with_active_layer(|layer| layer.outline[*ci].inner[*pi].clone());
+            let point = self.get_active_layer_ref().outline[*ci].inner[*pi].clone();
             points.push(Vector {
                 x: point.x as f64,
                 y: point.y as f64,

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -118,15 +118,13 @@ pub fn render_frame(v: &mut Editor, i: &mut Interface, canvas: &mut Canvas) {
                 draw_anchors(glif, &i.viewport, canvas);
             });
 
-            v.with_active_layer(|active_layer| {
-                points::draw_directions(
-                    &i.viewport,
-                    active_layer,
-                    canvas,
-                    &selected,
-                    pm != PreviewMode::None,
-                );
-            });
+            points::draw_directions(
+                &i.viewport,
+                v.get_active_layer_ref(),
+                canvas,
+                &selected,
+                pm != PreviewMode::None,
+            );
 
             v.dispatch_tool_draw(i, canvas);
         }

--- a/src/tool_behaviors/move_handle.rs
+++ b/src/tool_behaviors/move_handle.rs
@@ -42,7 +42,8 @@ impl MoveHandle {
 
         let (vci, vpi) = (v.contour_idx.unwrap(), v.point_idx.unwrap());
 
-        v.with_active_layer_mut(|layer| {
+        {
+            let layer = v.get_active_layer_mut();
             let handle = match self.wh {
                 WhichHandle::A => get_point!(layer, vci, vpi).a,
                 WhichHandle::B => get_point!(layer, vci, vpi).b,
@@ -79,7 +80,7 @@ impl MoveHandle {
             }
 
             get_contour_mut!(layer, vci).refigure_point_types();
-        });
+        }
     }
 
     pub fn mouse_released(&mut self, v: &mut Editor, _i: &mut Interface, mouse_info: MouseInfo) {

--- a/src/tool_behaviors/move_image.rs
+++ b/src/tool_behaviors/move_image.rs
@@ -30,22 +30,20 @@ impl MoveImage {
 
         self.mouse_info = mouse_info;
 
-        v.with_active_layer_mut(|layer| {
-            let affine = layer.images[self.selected_idx].1;
-            let raw_affine: Vec<f32> = affine.as_coeffs().iter().map(|x| *x as f32).collect();
+        let affine = v.get_active_layer_mut().images[self.selected_idx].1;
+        let raw_affine: Vec<f32> = affine.as_coeffs().iter().map(|x| *x as f32).collect();
 
-            let sk_affine = Matrix::from_affine(&raw_affine.try_into().unwrap());
-            let translate_mat = Matrix::translate((dx, dy));
+        let sk_affine = Matrix::from_affine(&raw_affine.try_into().unwrap());
+        let translate_mat = Matrix::translate((dx, dy));
 
-            let sk_affine = translate_mat * sk_affine;
+        let sk_affine = translate_mat * sk_affine;
 
-            let translated_raw_affine = sk_affine.to_affine();
+        let translated_raw_affine = sk_affine.to_affine();
 
-            if let Some(tra) = translated_raw_affine {
-                let tra: Vec<f64> = tra.iter().map(|x| *x as f64).collect();
-                layer.images[self.selected_idx].1 = Affine::new(tra.try_into().unwrap());
-            }
-        });
+        if let Some(tra) = translated_raw_affine {
+            let tra: Vec<f64> = tra.iter().map(|x| *x as f64).collect();
+            v.get_active_layer_mut().images[self.selected_idx].1 = Affine::new(tra.try_into().unwrap());
+        }
 
         self.last_position = mouse_info.position;
     }

--- a/src/tool_behaviors/rotate_image.rs
+++ b/src/tool_behaviors/rotate_image.rs
@@ -44,8 +44,9 @@ impl RotateImage {
 
         self.rotate_vector = normal_from_pivot.into();
 
-        v.with_active_layer_mut(|layer| {
-            let affine = layer.images[self.selected_idx].1.clone();
+        {
+            let layer = v.get_active_layer_mut();
+            let affine = layer.images[self.selected_idx].1;
             let raw_affine: Vec<f32> = affine.as_coeffs().iter().map(|x| *x as f32).collect();
 
             let sk_affine = Matrix::from_affine(&raw_affine.try_into().unwrap());
@@ -60,7 +61,7 @@ impl RotateImage {
                 let tra: Vec<f64> = tra.iter().map(|x| *x as f64).collect();
                 layer.images[self.selected_idx].1 = Affine::new(tra.try_into().unwrap());
             }
-        });
+        }
 
         return;
     }

--- a/src/tool_behaviors/rotate_selection.rs
+++ b/src/tool_behaviors/rotate_selection.rs
@@ -36,7 +36,8 @@ impl RotateSelection {
         let rotation_angle = normal_from_pivot.angle(rot_vec);
 
         for (ci, pi) in &v.selected.clone() {
-            v.with_active_layer_mut(|layer| {
+            {
+                let layer = v.get_active_layer_mut();
                 let old_point = get_point!(layer, *ci, *pi).clone();
                 let point_vec = Vector::from_components(old_point.x as f64, old_point.y as f64);
                 let rotated_point = point_vec.rotate(raw_pivot_vector, rotation_angle);
@@ -76,7 +77,7 @@ impl RotateSelection {
                         rotated_b.y as f32,
                     )
                 }
-            });
+            }
         }
 
         self.rotate_vector = normal_from_pivot.into();

--- a/src/tool_behaviors/selection_box.rs
+++ b/src/tool_behaviors/selection_box.rs
@@ -25,7 +25,7 @@ impl SelectionBox {
 
     pub fn mouse_moved(&mut self, v: &mut Editor, _i: &mut Interface, mouse_info: MouseInfo) {
         self.corner = Some(mouse_info.position);
-        let selected = v.with_active_layer(|layer| {
+        let selected = {
             // we get out starting mouse position, and our current mouse position
             let c1 = self.mouse_info.position;
             let c2 = mouse_info.position;
@@ -35,8 +35,8 @@ impl SelectionBox {
                 ((c2.0 - c1.0) as f32, (c2.1 - c1.1) as f32),
             );
 
-            build_box_selection(rect, &layer.outline)
-        });
+            build_box_selection(rect, &v.get_active_layer_ref().outline)
+        };
 
         self.selected = selected
     }
@@ -79,7 +79,8 @@ impl SelectionBox {
         for (ci, pi) in &self.selected {
             let (ci, pi) = (*ci, *pi);
 
-            v.with_active_layer(|layer| {
+            {
+                let layer = v.get_active_layer_ref();
                 let point = &get_point!(layer, ci, pi);
                 draw_point(
                     &i.viewport,
@@ -89,7 +90,7 @@ impl SelectionBox {
                     true,
                     canvas,
                 )
-            });
+            }
         }
     }
 }

--- a/src/tools/dash/dialog.rs
+++ b/src/tools/dash/dialog.rs
@@ -24,8 +24,7 @@ impl Dash {
                 };
                 let contour_idx = v.contour_idx.unwrap();
 
-                let operation =
-                    v.with_active_layer(|layer| layer.outline[contour_idx].operation.clone());
+                let operation = v.get_active_layer_ref().outline[contour_idx].operation.clone();
 
                 if let Some(ContourOperations::DashAlongPath { data }) = operation {
                     let mut new_width = data.stroke_width as f32;
@@ -158,9 +157,7 @@ impl Dash {
                         let new_op = ContourOperations::DashAlongPath { data: new_data };
 
                         v.begin_modification("Dash dialog modification.");
-                        v.with_active_layer_mut(|layer| {
-                            layer.outline[contour_idx].operation = Some(new_op.clone())
-                        });
+                        v.get_active_layer_mut().outline[contour_idx].operation = Some(new_op);
                         v.end_modification();
                     }
                 }

--- a/src/tools/image/dialog.rs
+++ b/src/tools/image/dialog.rs
@@ -24,19 +24,15 @@ impl Image {
                     if ui.is_item_clicked(imgui::MouseButton::Left) {
                         i.push_prompt(InputPrompt::Color {
                             label: "Layer color:".to_string(),
-                            default: v
-                                .with_active_layer(|layer| {
-                                    layer.images[selected]
+                            default:
+                                v.get_active_layer_mut().images[selected]
                                         .0
                                         .color
                                         .unwrap_or_else(|| [1., 1., 1., 1.].into())
-                                })
                                 .into(),
                             func: Rc::new(move |editor, color| {
                                 editor.begin_modification("Changed image color.");
-                                editor.with_active_layer_mut(|layer| {
-                                    layer.images[selected].0.color = color.map(|c| c.into())
-                                });
+                                editor.get_active_layer_mut().images[selected].0.color = color.map(|c| c.into());
                                 editor.end_modification();
 
                                 editor.recache_images();
@@ -49,7 +45,7 @@ impl Image {
                     if ui.is_item_clicked(imgui::MouseButton::Left) {
                         let default_mat = kurbo::Affine::default();
                         v.begin_modification("Reset image transform.");
-                        v.with_active_layer_mut(|layer| layer.images[selected].1 = default_mat);
+                        v.get_active_layer_mut().images[selected].1 = default_mat;
                         v.end_modification();
                     }
                 }

--- a/src/tools/pap/dialog.rs
+++ b/src/tools/pap/dialog.rs
@@ -57,8 +57,7 @@ impl PAP {
                 };
                 let contour_idx = v.contour_idx.unwrap();
 
-                let operation =
-                    v.with_active_layer(|layer| layer.outline[contour_idx].operation.clone());
+                let operation = v.get_active_layer_ref().outline[contour_idx].operation.clone();
 
                 // TODO: Clean this up. I could reduce the number of lines here by a lot if I make a few changes to how the function works,
                 // and add imgui utility functions for sliders and checkboxes.
@@ -83,9 +82,7 @@ impl PAP {
                         let new_op = ContourOperations::PatternAlongPath { data: new_data };
 
                         v.begin_modification("PAP dialog modification.");
-                        v.with_active_layer_mut(|layer| {
-                            layer.outline[contour_idx].operation = Some(new_op.clone())
-                        });
+                        v.get_active_layer_mut().outline[contour_idx].operation = Some(new_op);
                         v.end_modification();
                     }
 
@@ -119,9 +116,7 @@ impl PAP {
                         let new_op = ContourOperations::PatternAlongPath { data: new_data };
 
                         v.begin_modification("PAP dialog modification.");
-                        v.with_active_layer_mut(|layer| {
-                            layer.outline[contour_idx].operation = Some(new_op.clone())
-                        });
+                        v.get_active_layer_mut().outline[contour_idx].operation = Some(new_op);
                         v.end_modification();
                     }
 
@@ -133,9 +128,7 @@ impl PAP {
                         let new_op = ContourOperations::PatternAlongPath { data: new_data };
 
                         v.begin_modification("PAP dialog modification.");
-                        v.with_active_layer_mut(|layer| {
-                            layer.outline[contour_idx].operation = Some(new_op.clone())
-                        });
+                        v.get_active_layer_mut().outline[contour_idx].operation = Some(new_op);
                         v.end_modification();
                     }
 
@@ -160,9 +153,7 @@ impl PAP {
                         let new_op = ContourOperations::PatternAlongPath { data: new_data };
 
                         v.begin_modification("PAP dialog modification.");
-                        v.with_active_layer_mut(|layer| {
-                            layer.outline[contour_idx].operation = Some(new_op.clone())
-                        });
+                        v.get_active_layer_mut().outline[contour_idx].operation = Some(new_op);
                         v.end_modification();
                     }
 
@@ -175,9 +166,7 @@ impl PAP {
                         let new_op = ContourOperations::PatternAlongPath { data: new_data };
 
                         v.begin_modification("PAP dialog modification.");
-                        v.with_active_layer_mut(|layer| {
-                            layer.outline[contour_idx].operation = Some(new_op.clone())
-                        });
+                        v.get_active_layer_mut().outline[contour_idx].operation = Some(new_op);
                         v.end_modification();
                     }
 
@@ -195,9 +184,7 @@ impl PAP {
                         let new_op = ContourOperations::PatternAlongPath { data: new_data };
 
                         v.begin_modification("PAP dialog modification.");
-                        v.with_active_layer_mut(|layer| {
-                            layer.outline[contour_idx].operation = Some(new_op.clone())
-                        });
+                        v.get_active_layer_mut().outline[contour_idx].operation = Some(new_op);
                         v.end_modification();
                     }
 
@@ -215,9 +202,7 @@ impl PAP {
                         let new_op = ContourOperations::PatternAlongPath { data: new_data };
 
                         v.begin_modification("PAP dialog modification.");
-                        v.with_active_layer_mut(|layer| {
-                            layer.outline[contour_idx].operation = Some(new_op.clone())
-                        });
+                        v.get_active_layer_mut().outline[contour_idx].operation = Some(new_op);
                         v.end_modification();
                     }
 
@@ -235,9 +220,7 @@ impl PAP {
                         let new_op = ContourOperations::PatternAlongPath { data: new_data };
 
                         v.begin_modification("PAP dialog modification.");
-                        v.with_active_layer_mut(|layer| {
-                            layer.outline[contour_idx].operation = Some(new_op.clone())
-                        });
+                        v.get_active_layer_mut().outline[contour_idx].operation = Some(new_op);
                         v.end_modification();
                     }
 
@@ -263,9 +246,7 @@ impl PAP {
                         let new_op = ContourOperations::PatternAlongPath { data: new_data };
 
                         v.begin_modification("PAP dialog modification.");
-                        v.with_active_layer_mut(|layer| {
-                            layer.outline[contour_idx].operation = Some(new_op.clone())
-                        });
+                        v.get_active_layer_mut().outline[contour_idx].operation = Some(new_op);
                         v.end_modification();
                     }
 
@@ -280,9 +261,7 @@ impl PAP {
                         let new_op = ContourOperations::PatternAlongPath { data: new_data };
 
                         v.begin_modification("PAP overdraw changed.");
-                        v.with_active_layer_mut(|layer| {
-                            layer.outline[contour_idx].operation = Some(new_op.clone())
-                        });
+                        v.get_active_layer_mut().outline[contour_idx].operation = Some(new_op);
                         v.end_modification();
                         v.collapse_history_entries();
                     }
@@ -296,9 +275,7 @@ impl PAP {
                         let new_op = ContourOperations::PatternAlongPath { data: new_data };
 
                         v.begin_modification("PAP dialog modification.");
-                        v.with_active_layer_mut(|layer| {
-                            layer.outline[contour_idx].operation = Some(new_op.clone())
-                        });
+                        v.get_active_layer_mut().outline[contour_idx].operation = Some(new_op);
                         v.end_modification();
                     }
 
@@ -310,9 +287,7 @@ impl PAP {
                         let new_op = ContourOperations::PatternAlongPath { data: new_data };
 
                         v.begin_modification("PAP dialog modification.");
-                        v.with_active_layer_mut(|layer| {
-                            layer.outline[contour_idx].operation = Some(new_op.clone())
-                        });
+                        v.get_active_layer_mut().outline[contour_idx].operation = Some(new_op);
                         v.end_modification();
                     }
 
@@ -325,9 +300,7 @@ impl PAP {
                         let new_op = ContourOperations::PatternAlongPath { data: new_data };
 
                         v.begin_modification("PAP dialog modification.");
-                        v.with_active_layer_mut(|layer| {
-                            layer.outline[contour_idx].operation = Some(new_op.clone())
-                        });
+                        v.get_active_layer_mut().outline[contour_idx].operation = Some(new_op);
                         v.end_modification();
                     }
                 }

--- a/src/tools/pap/mod.rs
+++ b/src/tools/pap/mod.rs
@@ -27,13 +27,14 @@ impl Tool for PAP {
     }
 
     fn ui(&mut self, v: &mut Editor, i: &mut Interface, ui: &mut Ui) {
-        let show_dialog = v.with_active_layer(|layer| match v.contour_idx {
-            Some(ci) => match layer.outline[ci].operation {
+        let show_dialog = match v.contour_idx {
+            Some(ci) => match v.get_active_layer_ref().outline[ci].operation {
                 Some(ContourOperations::PatternAlongPath { .. }) => true,
                 _ => false,
             },
             _ => false,
-        });
+        };
+
         if show_dialog {
             self.tool_dialog(v, i, ui);
         }
@@ -50,7 +51,7 @@ impl PAP {
             v.contour_idx = Some(ci);
             v.point_idx = Some(pi);
 
-            let layer_op = v.with_active_layer(|layer| layer.outline[ci].operation.clone());
+            let layer_op = v.get_active_layer_ref().outline[ci].operation.clone();
 
             match layer_op {
                 Some(ContourOperations::PatternAlongPath { .. }) => (),
@@ -59,29 +60,27 @@ impl PAP {
                         label: "Select a pattern.".to_string(),
                         func: Rc::new(move |editor, source_layer| {
                             editor.begin_modification("Added PAP contour.");
-                            editor.with_active_layer_mut(|layer| {
-                                layer.outline[ci].operation =
-                                    Some(ContourOperations::PatternAlongPath {
-                                        // TODO: Default() implementation for many of our structs.
-                                        data: PAPContour {
-                                            pattern: source_layer.outline.clone(),
-                                            copies: PatternCopies::Repeated,
-                                            subdivide: PatternSubdivide::Off,
-                                            is_vertical: false,
-                                            stretch: PatternStretch::On,
-                                            spacing: 4.,
-                                            simplify: false,
-                                            normal_offset: 0.,
-                                            tangent_offset: 0.,
-                                            pattern_scale: (1., 1.),
-                                            center_pattern: true,
-                                            prevent_overdraw: 0.,
-                                            two_pass_culling: false,
-                                            reverse_path: false,
-                                            reverse_culling: false,
-                                        },
-                                    })
-                            });
+                            editor.get_active_layer_mut().outline[ci].operation =
+                                Some(ContourOperations::PatternAlongPath {
+                                    // TODO: Default() implementation for many of our structs.
+                                    data: PAPContour {
+                                        pattern: source_layer.outline.clone(),
+                                        copies: PatternCopies::Repeated,
+                                        subdivide: PatternSubdivide::Off,
+                                        is_vertical: false,
+                                        stretch: PatternStretch::On,
+                                        spacing: 4.,
+                                        simplify: false,
+                                        normal_offset: 0.,
+                                        tangent_offset: 0.,
+                                        pattern_scale: (1., 1.),
+                                        center_pattern: true,
+                                        prevent_overdraw: 0.,
+                                        two_pass_culling: false,
+                                        reverse_path: false,
+                                        reverse_culling: false,
+                                    },
+                                });
                             editor.end_modification();
                         }),
                     });

--- a/src/tools/pen.rs
+++ b/src/tools/pen.rs
@@ -47,8 +47,7 @@ impl Pen {
         // If that is the case we merge them
         if let (Some(c_idx), Some(p_idx)) = (v.contour_idx, v.point_idx) {
             // we've clicked a point?
-            if let Some((info_ci, info_pi, _)) =
-                clicked_point_or_handle(v, i, mouse_info.raw_position, None)
+            if let Some((info_ci, info_pi, _)) = clicked_point_or_handle(v, i, mouse_info.raw_position, None)
             {
                 // we have the end of one contour active and clicked the start of another?
                 let end_is_active =
@@ -57,15 +56,11 @@ impl Pen {
                     get_contour_start_or_end(v, info_ci, info_pi) == Some(SelectPointInfo::Start);
 
                 // make sure these contours are open
-                let selected_open =
-                    v.with_active_layer(|layer| get_contour_type!(layer, c_idx)) == PointType::Move;
-                let target_open = v.with_active_layer(|layer| get_contour_type!(layer, info_ci))
-                    == PointType::Move;
+                let selected_open = get_contour_type!(v.get_active_layer_ref(), c_idx) == PointType::Move;
+                let target_open = get_contour_type!(v.get_active_layer_ref(), info_ci) == PointType::Move;
                 if end_is_active && start_is_clicked && selected_open && target_open {
-                    v.with_active_layer_mut(|layer| {
-                        let new_point = get_point!(layer, info_ci, info_pi).clone();
-                        get_contour_mut!(layer, c_idx).push(new_point);
-                    });
+                    let new_point = get_point!(v.get_active_layer_ref(), info_ci, info_pi).clone();
+                    get_contour_mut!(v.get_active_layer_mut(), c_idx).push(new_point);
                     v.merge_contours(info_ci, c_idx);
                     v.end_modification();
                     return;
@@ -75,56 +70,55 @@ impl Pen {
 
         // Next we check if our mouse is over an existing curve. If so we add a point to the curve.
         if let Some(info) = nearest_point_on_curve(v, i, mouse_info.position) {
-            v.with_active_layer_mut(|layer| {
-                let mut second_idx_zero = false;
-                let contour = &mut layer.outline[info.contour_idx];
-                let mut point = contour.inner.remove(info.seg_idx);
-                let mut next_point = if info.seg_idx == contour.inner.len() {
-                    second_idx_zero = true;
-                    contour.inner.remove(0)
+            let mut second_idx_zero = false;
+            let contour = &mut v.get_active_layer_mut().outline[info.contour_idx];
+            let mut point = contour.inner.remove(info.seg_idx);
+            let mut next_point = if info.seg_idx == contour.inner.len() {
+                second_idx_zero = true;
+                contour.inner.remove(0)
+            } else {
+                contour.inner.remove(info.seg_idx)
+            };
+
+            let bez = Bezier::from(&point, &next_point);
+            let subdivisions = bez.subdivide(info.t);
+
+            if let Some(subdivisions) = subdivisions {
+                let (sub_a, sub_b) = (
+                    subdivisions.0.to_control_points(),
+                    subdivisions.1.to_control_points(),
+                );
+                point.a = sub_a[1].to_handle();
+                next_point.b = sub_b[2].to_handle();
+
+                if second_idx_zero {
+                    contour.inner.insert(0, next_point);
                 } else {
-                    contour.inner.remove(info.seg_idx)
-                };
-
-                let bez = Bezier::from(&point, &next_point);
-                let subdivisions = bez.subdivide(info.t);
-
-                if let Some(subdivisions) = subdivisions {
-                    let (sub_a, sub_b) = (
-                        subdivisions.0.to_control_points(),
-                        subdivisions.1.to_control_points(),
-                    );
-                    point.a = sub_a[1].to_handle();
-                    next_point.b = sub_b[2].to_handle();
-
-                    if second_idx_zero {
-                        contour.inner.insert(0, next_point);
-                    } else {
-                        contour.inner.insert(info.seg_idx, next_point);
-                    }
-
-                    let (x, y) = (sub_a[3].x, sub_a[3].y);
-                    contour.inner.insert(
-                        info.seg_idx,
-                        Point::from_x_y_a_b_type(
-                            (x as f32, y as f32),
-                            (sub_b[1].to_handle(), sub_a[2].to_handle()),
-                            PointType::Curve,
-                        ),
-                    );
-                    contour.operation = contour_operations::insert(contour, info.seg_idx);
-                    contour.inner.insert(info.seg_idx, point);
+                    contour.inner.insert(info.seg_idx, next_point);
                 }
-            });
+
+                let (x, y) = (sub_a[3].x, sub_a[3].y);
+                contour.inner.insert(
+                    info.seg_idx,
+                    Point::from_x_y_a_b_type(
+                        (x as f32, y as f32),
+                        (sub_b[1].to_handle(), sub_a[2].to_handle()),
+                        PointType::Curve,
+                    ),
+                );
+                contour.operation = contour_operations::insert(contour, info.seg_idx);
+                contour.inner.insert(info.seg_idx, point);
+            }
             v.end_modification();
         }
         // If we've got the end of a contour selected we'll continue drawing that contour.
         else if let Some(contour_idx) = v.contour_idx {
             let mouse_pos = mouse_info.position;
-            let contour_len = v.with_active_layer(|layer| get_contour_len!(layer, contour_idx));
+            let contour_len = get_contour_len!(v.get_active_layer_ref(), contour_idx);
 
             if v.point_idx.unwrap() == contour_len - 1 {
-                v.point_idx = v.with_active_layer_mut(|layer| {
+                v.point_idx = {
+                    let layer = v.get_active_layer_mut();
                     get_contour!(layer, contour_idx).push(Point::from_x_y_type(
                         (mouse_pos.0 as f32, mouse_pos.1 as f32),
                         PointType::Curve,
@@ -133,9 +127,10 @@ impl Pen {
                     layer.outline[contour_idx].operation =
                         contour_operations::insert(&layer.outline[contour_idx], contour_len);
                     Some(get_contour_len!(layer, contour_idx) - 1)
-                });
+                };
             } else if v.point_idx.unwrap() == 0 {
-                v.with_active_layer_mut(|layer| {
+                {
+                    let layer = v.get_active_layer_mut();
                     let point_type = get_point!(layer, contour_idx, 0).ptype;
 
                     if get_point!(layer, contour_idx, 0).ptype == PointType::Move {
@@ -148,13 +143,14 @@ impl Pen {
 
                     layer.outline[contour_idx].operation =
                         contour_operations::insert(&layer.outline[contour_idx], 0);
-                });
+                };
                 v.end_modification();
             }
         } else {
             // Lastly if we get here we create a new contour.
             let mouse_pos = mouse_info.position;
-            v.contour_idx = v.with_active_layer_mut(|layer| {
+            v.contour_idx = {
+                let layer = v.get_active_layer_mut();
                 let mut new_contour: Contour<MFEKGlifPointData> = Vec::new();
                 new_contour.push(Point::from_x_y_type(
                     (mouse_pos.0 as f32, mouse_pos.1 as f32),
@@ -167,7 +163,7 @@ impl Pen {
 
                 layer.outline.push(new_contour.into());
                 Some(layer.outline.len() - 1)
-            });
+            };
             v.end_modification();
             v.point_idx = Some(0);
         }
@@ -212,13 +208,10 @@ impl Pen {
                     get_contour_start_or_end(v, info_ci, info_pi) == Some(SelectPointInfo::Start);
 
                 // make sure these contours are open
-                let selected_open =
-                    v.with_active_layer(|layer| get_contour_type!(layer, c_idx)) == PointType::Move;
-                let target_open = v.with_active_layer(|layer| get_contour_type!(layer, info_ci))
-                    == PointType::Move;
+                let selected_open = get_contour_type!(v.get_active_layer_ref(), c_idx) == PointType::Move;
+                let target_open = get_contour_type!(v.get_active_layer_ref(), info_ci) == PointType::Move;
                 if end_is_active && start_is_clicked && selected_open && target_open {
-                    let point =
-                        v.with_active_layer(|layer| get_contour!(layer, info_ci)[info_pi].clone());
+                    let point = get_contour!(v.get_active_layer_ref(), info_ci)[info_pi].clone();
                     draw_point(
                         &i.viewport,
                         &point,

--- a/src/tools/vws/dialog.rs
+++ b/src/tools/vws/dialog.rs
@@ -89,9 +89,7 @@ impl VWS {
                 let new_op = ContourOperations::VariableWidthStroke { data: new_data };
 
                 v.begin_modification("VWS dialog modification.");
-                v.with_active_layer_mut(|layer| {
-                    layer.outline[contour_idx].operation = Some(new_op.clone())
-                });
+                v.get_active_layer_mut().outline[contour_idx].operation = Some(new_op);
                 v.end_modification();
             }
         }
@@ -124,9 +122,7 @@ impl VWS {
                 let new_op = ContourOperations::VariableWidthStroke { data: new_data };
 
                 v.begin_modification("VWS dialog modification.");
-                v.with_active_layer_mut(|layer| {
-                    layer.outline[contour_idx].operation = Some(new_op.clone())
-                });
+                v.get_active_layer_mut().outline[contour_idx].operation = Some(new_op);
                 v.end_modification();
             }
         }

--- a/src/tools/vws/mod.rs
+++ b/src/tools/vws/mod.rs
@@ -35,13 +35,13 @@ impl Tool for VWS {
     }
 
     fn ui(&mut self, v: &mut Editor, i: &mut Interface, ui: &mut Ui) {
-        let show_dialog = v.with_active_layer(|layer| match v.contour_idx {
-            Some(ci) => match layer.outline[ci].operation {
+        let show_dialog = match v.contour_idx {
+            Some(ci) => match v.get_active_layer_ref().outline[ci].operation {
                 Some(ContourOperations::VariableWidthStroke { .. }) => true,
                 _ => false,
             },
             _ => false,
-        });
+        };
         if show_dialog {
             self.tool_dialog(v, i, ui);
         }
@@ -70,69 +70,67 @@ impl VWS {
     }
 
     pub fn draw_handles(&self, v: &Editor, i: &Interface, canvas: &mut Canvas) {
-        v.with_active_layer(|layer| {
-            let factor = i.viewport.factor;
+        let factor = i.viewport.factor;
 
-            for (contour_idx, contour) in layer.outline.iter().enumerate() {
-                let contour_pw = Piecewise::from(contour);
+        for (contour_idx, contour) in v.get_active_layer_ref().outline.iter().enumerate() {
+            let contour_pw = Piecewise::from(contour);
 
-                for (vws_handle_idx, bezier) in contour_pw.segs.iter().enumerate() {
-                    let start_point = bezier.start_point();
+            for (vws_handle_idx, bezier) in contour_pw.segs.iter().enumerate() {
+                let start_point = bezier.start_point();
 
-                    let (handle_pos_left, handle_pos_right) = match (
-                        get_vws_handle_pos(v, contour_idx, vws_handle_idx, WhichHandle::A),
-                        get_vws_handle_pos(v, contour_idx, vws_handle_idx, WhichHandle::B),
-                    ) {
-                        (Ok(l), Ok(r)) => (l.2, r.2),
-                        (_e_l, _e_r) => continue,
-                    };
+                let (handle_pos_left, handle_pos_right) = match (
+                    get_vws_handle_pos(v, contour_idx, vws_handle_idx, WhichHandle::A),
+                    get_vws_handle_pos(v, contour_idx, vws_handle_idx, WhichHandle::B),
+                ) {
+                    (Ok(l), Ok(r)) => (l.2, r.2),
+                    (_e_l, _e_r) => continue,
+                };
 
-                    let mut path = SkiaPath::new();
-                    let mut paint = Paint::default();
+                let mut path = SkiaPath::new();
+                let mut paint = Paint::default();
 
-                    paint.set_anti_alias(true);
-                    paint.set_color(RIB_STROKE);
-                    paint.set_stroke_width(HANDLEBAR_THICKNESS * (1. / factor));
-                    paint.set_style(PaintStyle::Stroke);
+                paint.set_anti_alias(true);
+                paint.set_color(RIB_STROKE);
+                paint.set_stroke_width(HANDLEBAR_THICKNESS * (1. / factor));
+                paint.set_style(PaintStyle::Stroke);
 
-                    path.move_to((handle_pos_left.x as f32, handle_pos_left.y as f32));
-                    path.line_to((start_point.x as f32, start_point.y as f32));
-                    path.line_to((handle_pos_right.x as f32, handle_pos_right.y as f32));
+                path.move_to((handle_pos_left.x as f32, handle_pos_left.y as f32));
+                path.line_to((start_point.x as f32, start_point.y as f32));
+                path.line_to((handle_pos_right.x as f32, handle_pos_right.y as f32));
 
-                    canvas.draw_path(&path, &paint);
-                }
-
-                if contour.inner.first().unwrap().ptype == glifparser::PointType::Move {
-                    if contour_pw.segs.len() < 1 {
-                        continue;
-                    };
-                    let vws_handle_idx = contour_pw.segs.len();
-                    let bezier = contour_pw.segs.last().unwrap();
-                    let start_point = bezier.end_point();
-
-                    let (handle_pos_left, handle_pos_right) = match (
-                        get_vws_handle_pos(v, contour_idx, vws_handle_idx, WhichHandle::A),
-                        get_vws_handle_pos(v, contour_idx, vws_handle_idx, WhichHandle::B),
-                    ) {
-                        (Ok(l), Ok(r)) => (l.2, r.2),
-                        (_e_l, _e_r) => continue,
-                    };
-
-                    let mut path = SkiaPath::new();
-                    let mut paint = Paint::default();
-
-                    paint.set_anti_alias(true);
-                    paint.set_color(RIB_STROKE);
-                    paint.set_stroke_width(HANDLEBAR_THICKNESS * (1. / factor));
-                    paint.set_style(PaintStyle::Stroke);
-
-                    path.move_to((handle_pos_left.x as f32, handle_pos_left.y as f32));
-                    path.line_to((start_point.x as f32, start_point.y as f32));
-                    path.line_to((handle_pos_right.x as f32, handle_pos_right.y as f32));
-
-                    canvas.draw_path(&path, &paint);
-                }
+                canvas.draw_path(&path, &paint);
             }
-        })
+
+            if contour.inner.first().unwrap().ptype == glifparser::PointType::Move {
+                if contour_pw.segs.len() < 1 {
+                    continue;
+                };
+                let vws_handle_idx = contour_pw.segs.len();
+                let bezier = contour_pw.segs.last().unwrap();
+                let start_point = bezier.end_point();
+
+                let (handle_pos_left, handle_pos_right) = match (
+                    get_vws_handle_pos(v, contour_idx, vws_handle_idx, WhichHandle::A),
+                    get_vws_handle_pos(v, contour_idx, vws_handle_idx, WhichHandle::B),
+                ) {
+                    (Ok(l), Ok(r)) => (l.2, r.2),
+                    (_e_l, _e_r) => continue,
+                };
+
+                let mut path = SkiaPath::new();
+                let mut paint = Paint::default();
+
+                paint.set_anti_alias(true);
+                paint.set_color(RIB_STROKE);
+                paint.set_stroke_width(HANDLEBAR_THICKNESS * (1. / factor));
+                paint.set_style(PaintStyle::Stroke);
+
+                path.move_to((handle_pos_left.x as f32, handle_pos_left.y as f32));
+                path.line_to((start_point.x as f32, start_point.y as f32));
+                path.line_to((handle_pos_right.x as f32, handle_pos_right.y as f32));
+
+                canvas.draw_path(&path, &paint);
+            }
+        }
     }
 }

--- a/src/tools/vws/util.rs
+++ b/src/tools/vws/util.rs
@@ -8,24 +8,20 @@ use MFEKmath::{Evaluate, Piecewise, Vector};
 // This file holds utility functions for working with vws. Things like if a handle is clicked.
 
 pub fn get_vws_contour(v: &Editor, contour_idx: usize) -> Option<VWSContour> {
-    v.with_active_layer(|layer| {
-        if let Some(contour_op) = layer.outline[contour_idx].operation.clone() {
-            return if let ContourOperations::VariableWidthStroke { data } = contour_op {
-                Some(data)
-            } else {
-                None
-            };
-        }
+    if let Some(contour_op) = v.get_active_layer_ref().outline[contour_idx].operation.clone() {
+        return if let ContourOperations::VariableWidthStroke { data } = contour_op {
+            Some(data)
+        } else {
+            None
+        };
+    }
 
-        None
-    })
+    None
 }
 
 pub fn set_vws_contour(v: &mut Editor, contour_idx: usize, contour: VWSContour) {
-    v.with_active_layer_mut(|layer| {
-        layer.outline[contour_idx].operation = Some(ContourOperations::VariableWidthStroke {
-            data: contour.clone(),
-        });
+    v.get_active_layer_mut().outline[contour_idx].operation = Some(ContourOperations::VariableWidthStroke {
+        data: contour.clone(),
     });
 }
 
@@ -78,56 +74,54 @@ pub fn set_vws_handle(
         generate_vws_contour(v, contour_idx)
     };
 
-    v.with_active_layer_mut(|layer| {
-        let contour_pw = Piecewise::from(&get_contour!(layer, contour_idx));
+    let contour_pw = Piecewise::from(&get_contour!(v.get_active_layer_ref(), contour_idx));
 
-        let side_multiplier = match side {
-            WhichHandle::A => 1.,
-            WhichHandle::B => -1.,
-            _ => unreachable!(),
-        };
+    let side_multiplier = match side {
+        WhichHandle::A => 1.,
+        WhichHandle::B => -1.,
+        _ => unreachable!(),
+    };
 
-        let tangent_offset = if constrain {
-            0.
-        } else {
-            side_multiplier * tangent_offset
-        };
+    let tangent_offset = if constrain {
+        0.
+    } else {
+        side_multiplier * tangent_offset
+    };
 
-        // if we're editing the first point we need to mirror it in the 'imaginary' last point
-        if point_idx == 0 && contour_pw.is_closed() {
-            let last_handle = vws_contour.handles.len() - 1;
-
-            match side {
-                WhichHandle::A => vws_contour.handles[last_handle].left_offset = normal_offset,
-                WhichHandle::B => vws_contour.handles[last_handle].right_offset = normal_offset,
-                _ => {}
-            }
-
-            vws_contour.handles[last_handle].tangent_offset = tangent_offset;
-            if mirror {
-                vws_contour.handles[last_handle].left_offset = normal_offset;
-                vws_contour.handles[last_handle].right_offset = normal_offset;
-            }
-        }
+    // if we're editing the first point we need to mirror it in the 'imaginary' last point
+    if point_idx == 0 && contour_pw.is_closed() {
+        let last_handle = vws_contour.handles.len() - 1;
 
         match side {
-            WhichHandle::A => {
-                vws_contour.handles[point_idx].left_offset = normal_offset;
-            }
-            WhichHandle::B => {
-                vws_contour.handles[point_idx].right_offset = normal_offset;
-            }
+            WhichHandle::A => vws_contour.handles[last_handle].left_offset = normal_offset,
+            WhichHandle::B => vws_contour.handles[last_handle].right_offset = normal_offset,
             _ => {}
         }
 
+        vws_contour.handles[last_handle].tangent_offset = tangent_offset;
         if mirror {
-            vws_contour.handles[point_idx].left_offset = normal_offset;
-            vws_contour.handles[point_idx].right_offset = normal_offset;
-            vws_contour.handles[point_idx].tangent_offset = tangent_offset;
-        } else {
-            vws_contour.handles[point_idx].tangent_offset = tangent_offset;
+            vws_contour.handles[last_handle].left_offset = normal_offset;
+            vws_contour.handles[last_handle].right_offset = normal_offset;
         }
-    });
+    }
+
+    match side {
+        WhichHandle::A => {
+            vws_contour.handles[point_idx].left_offset = normal_offset;
+        }
+        WhichHandle::B => {
+            vws_contour.handles[point_idx].right_offset = normal_offset;
+        }
+        _ => {}
+    }
+
+    if mirror {
+        vws_contour.handles[point_idx].left_offset = normal_offset;
+        vws_contour.handles[point_idx].right_offset = normal_offset;
+        vws_contour.handles[point_idx].tangent_offset = tangent_offset;
+    } else {
+        vws_contour.handles[point_idx].tangent_offset = tangent_offset;
+    }
 
     set_vws_contour(v, contour_idx, vws_contour);
 }
@@ -159,71 +153,69 @@ pub fn get_vws_handle_pos(
     handle_idx: usize,
     side: WhichHandle,
 ) -> Result<(Vector, Vector, Vector), ()> {
-    v.with_active_layer(|layer| {
-        let vws_contour =
-            get_vws_contour(v, contour_idx).unwrap_or_else(|| generate_vws_contour(v, contour_idx));
-        let contour_pw = Piecewise::from(&get_contour!(layer, contour_idx));
+    let vws_contour =
+        get_vws_contour(v, contour_idx).unwrap_or_else(|| generate_vws_contour(v, contour_idx));
+    let contour_pw = Piecewise::from(&get_contour!(v.get_active_layer_ref(), contour_idx));
 
-        if handle_idx > vws_contour.handles.len() - 1 {
-            log::warn!(
-                "Failed to get requested VWS len position ({}/{}).",
-                handle_idx,
-                vws_contour.handles.len() - 1
-            );
-            return Err(());
+    if handle_idx > vws_contour.handles.len() - 1 {
+        log::warn!(
+            "Failed to get requested VWS len position ({}/{}).",
+            handle_idx,
+            vws_contour.handles.len() - 1
+        );
+        return Err(());
+    }
+    let vws_handle = vws_contour.handles[handle_idx];
+
+    // if we've got an open contour and are dealing with the last handle we need special logic
+    let (_bezier, start_point, tangent, normal) = if handle_idx == contour_pw.segs.len() {
+        let bezier = &contour_pw.segs[handle_idx - 1];
+        let start_point = bezier.end_point();
+        let tangent = bezier.tangent_at(1.).normalize();
+        let normal = Vector {
+            x: tangent.y,
+            y: -tangent.x,
         }
-        let vws_handle = vws_contour.handles[handle_idx];
+        .normalize();
 
-        // if we've got an open contour and are dealing with the last handle we need special logic
-        let (_bezier, start_point, tangent, normal) = if handle_idx == contour_pw.segs.len() {
-            let bezier = &contour_pw.segs[handle_idx - 1];
-            let start_point = bezier.end_point();
-            let tangent = bezier.tangent_at(1.).normalize();
-            let normal = Vector {
-                x: tangent.y,
-                y: -tangent.x,
-            }
-            .normalize();
+        (bezier, start_point, tangent, normal)
+    } else {
+        let bezier = &contour_pw.segs[handle_idx];
+        let start_point = bezier.start_point();
+        let tangent = bezier.tangent_at(0.).normalize();
+        let normal = Vector {
+            x: tangent.y,
+            y: -tangent.x,
+        }
+        .normalize();
 
-            (bezier, start_point, tangent, normal)
-        } else {
-            let bezier = &contour_pw.segs[handle_idx];
-            let start_point = bezier.start_point();
-            let tangent = bezier.tangent_at(0.).normalize();
-            let normal = Vector {
-                x: tangent.y,
-                y: -tangent.x,
-            }
-            .normalize();
+        (bezier, start_point, tangent, normal)
+    };
 
-            (bezier, start_point, tangent, normal)
-        };
+    let max_tangent = f64::max(vws_handle.right_offset, vws_handle.left_offset);
 
-        let max_tangent = f64::max(vws_handle.right_offset, vws_handle.left_offset);
+    let scaled_tangent_offset = match side {
+        WhichHandle::A => vws_handle.left_offset / max_tangent,
+        WhichHandle::B => vws_handle.right_offset / max_tangent,
+        WhichHandle::Neither => panic!("Should be unreachable!"),
+    };
 
-        let scaled_tangent_offset = match side {
-            WhichHandle::A => vws_handle.left_offset / max_tangent,
-            WhichHandle::B => vws_handle.right_offset / max_tangent,
-            WhichHandle::Neither => panic!("Should be unreachable!"),
-        };
-
-        Ok(match side {
-            WhichHandle::A => (
-                start_point,
-                tangent,
-                start_point
-                    + normal * vws_handle.left_offset
-                    + tangent * -vws_handle.tangent_offset * scaled_tangent_offset,
-            ),
-            WhichHandle::B => (
-                start_point,
-                tangent,
-                start_point
-                    + normal * -vws_handle.right_offset
-                    + tangent * vws_handle.tangent_offset * scaled_tangent_offset,
-            ),
-            _ => unreachable!(),
-        })
+    Ok(match side {
+        WhichHandle::A => (
+            start_point,
+            tangent,
+            start_point
+                + normal * vws_handle.left_offset
+                + tangent * -vws_handle.tangent_offset * scaled_tangent_offset,
+        ),
+        WhichHandle::B => (
+            start_point,
+            tangent,
+            start_point
+                + normal * -vws_handle.right_offset
+                + tangent * vws_handle.tangent_offset * scaled_tangent_offset,
+        ),
+        _ => unreachable!(),
     })
 }
 
@@ -237,16 +229,14 @@ fn generate_vws_contour(v: &Editor, contour_idx: usize) -> VWSContour {
         remove_external: false,
     };
 
-    v.with_active_layer(|layer| {
-        for _i in 0..get_contour_len!(layer, contour_idx) + 1 {
-            new_vws_contour.handles.push(VWSHandle {
-                left_offset: 10.,
-                right_offset: 10.,
-                interpolation: InterpolationType::Linear,
-                tangent_offset: 0.,
-            })
-        }
-    });
+    for _i in 0..get_contour_len!(v.get_active_layer_ref(), contour_idx) + 1 {
+        new_vws_contour.handles.push(VWSHandle {
+            left_offset: 10.,
+            right_offset: 10.,
+            interpolation: InterpolationType::Linear,
+            tangent_offset: 0.,
+        })
+    }
 
     new_vws_contour
 }
@@ -259,76 +249,74 @@ pub fn clicked_handle(
     let factor = i.viewport.factor;
     let mouse_pos = meta.position;
 
-    v.with_active_layer(|layer| {
-        for (contour_idx, contour) in layer.outline.iter().enumerate() {
-            let contour_pw = Piecewise::from(contour);
+    for (contour_idx, contour) in v.get_active_layer_ref().outline.iter().enumerate() {
+        let contour_pw = Piecewise::from(contour);
 
-            let size = ((POINT_RADIUS * 2.) + (POINT_STROKE_THICKNESS * 2.)) * (1. / factor);
-            for vws_handle_idx in 0..contour_pw.segs.len() {
-                let (handle_pos_left, handle_pos_right) = match (
-                    get_vws_handle_pos(v, contour_idx, vws_handle_idx, WhichHandle::A),
-                    get_vws_handle_pos(v, contour_idx, vws_handle_idx, WhichHandle::B),
-                ) {
-                    (Ok(l), Ok(r)) => (l.2, r.2),
-                    (_e_l, _e_r) => return None,
-                };
+        let size = ((POINT_RADIUS * 2.) + (POINT_STROKE_THICKNESS * 2.)) * (1. / factor);
+        for vws_handle_idx in 0..contour_pw.segs.len() {
+            let (handle_pos_left, handle_pos_right) = match (
+                get_vws_handle_pos(v, contour_idx, vws_handle_idx, WhichHandle::A),
+                get_vws_handle_pos(v, contour_idx, vws_handle_idx, WhichHandle::B),
+            ) {
+                (Ok(l), Ok(r)) => (l.2, r.2),
+                (_e_l, _e_r) => return None,
+            };
 
-                let handle_left_point = SkPoint::new(
-                    handle_pos_left.x as f32 - (size / 2.),
-                    handle_pos_left.y as f32 - (size / 2.),
-                );
-                let handle_left_rect = SkRect::from_point_and_size(handle_left_point, (size, size));
+            let handle_left_point = SkPoint::new(
+                handle_pos_left.x as f32 - (size / 2.),
+                handle_pos_left.y as f32 - (size / 2.),
+            );
+            let handle_left_rect = SkRect::from_point_and_size(handle_left_point, (size, size));
 
-                let handle_right_point = SkPoint::new(
-                    handle_pos_right.x as f32 - (size / 2.),
-                    handle_pos_right.y as f32 - (size / 2.),
-                );
-                let handle_right_rect =
-                    SkRect::from_point_and_size(handle_right_point, (size, size));
+            let handle_right_point = SkPoint::new(
+                handle_pos_right.x as f32 - (size / 2.),
+                handle_pos_right.y as f32 - (size / 2.),
+            );
+            let handle_right_rect =
+                SkRect::from_point_and_size(handle_right_point, (size, size));
 
-                let sk_mpos = SkPoint::new(mouse_pos.0 as f32, mouse_pos.1 as f32);
+            let sk_mpos = SkPoint::new(mouse_pos.0 as f32, mouse_pos.1 as f32);
 
-                if handle_left_rect.contains(sk_mpos) {
-                    return Some((contour_idx, vws_handle_idx, WhichHandle::A));
-                } else if handle_right_rect.contains(sk_mpos) {
-                    return Some((contour_idx, vws_handle_idx, WhichHandle::B));
-                }
-            }
-
-            if contour.inner.first().unwrap().ptype == glifparser::PointType::Move {
-                let vws_handle_idx = contour_pw.segs.len();
-
-                let (handle_pos_left, handle_pos_right) = match (
-                    get_vws_handle_pos(v, contour_idx, vws_handle_idx, WhichHandle::A),
-                    get_vws_handle_pos(v, contour_idx, vws_handle_idx, WhichHandle::B),
-                ) {
-                    (Ok(l), Ok(r)) => (l.2, r.2),
-                    (_e_l, _e_r) => return None,
-                };
-
-                let handle_left_point = SkPoint::new(
-                    handle_pos_left.x as f32 - (size / 2.),
-                    handle_pos_left.y as f32 - (size / 2.),
-                );
-                let handle_left_rect = SkRect::from_point_and_size(handle_left_point, (size, size));
-
-                let handle_right_point = SkPoint::new(
-                    handle_pos_right.x as f32 - (size / 2.),
-                    handle_pos_right.y as f32 - (size / 2.),
-                );
-                let handle_right_rect =
-                    SkRect::from_point_and_size(handle_right_point, (size, size));
-
-                let sk_mpos = SkPoint::new(meta.position.0 as f32, meta.position.1 as f32);
-
-                if handle_left_rect.contains(sk_mpos) {
-                    return Some((contour_idx, vws_handle_idx, WhichHandle::A));
-                } else if handle_right_rect.contains(sk_mpos) {
-                    return Some((contour_idx, vws_handle_idx, WhichHandle::B));
-                }
+            if handle_left_rect.contains(sk_mpos) {
+                return Some((contour_idx, vws_handle_idx, WhichHandle::A));
+            } else if handle_right_rect.contains(sk_mpos) {
+                return Some((contour_idx, vws_handle_idx, WhichHandle::B));
             }
         }
 
-        None
-    })
+        if contour.inner.first().unwrap().ptype == glifparser::PointType::Move {
+            let vws_handle_idx = contour_pw.segs.len();
+
+            let (handle_pos_left, handle_pos_right) = match (
+                get_vws_handle_pos(v, contour_idx, vws_handle_idx, WhichHandle::A),
+                get_vws_handle_pos(v, contour_idx, vws_handle_idx, WhichHandle::B),
+            ) {
+                (Ok(l), Ok(r)) => (l.2, r.2),
+                (_e_l, _e_r) => return None,
+            };
+
+            let handle_left_point = SkPoint::new(
+                handle_pos_left.x as f32 - (size / 2.),
+                handle_pos_left.y as f32 - (size / 2.),
+            );
+            let handle_left_rect = SkRect::from_point_and_size(handle_left_point, (size, size));
+
+            let handle_right_point = SkPoint::new(
+                handle_pos_right.x as f32 - (size / 2.),
+                handle_pos_right.y as f32 - (size / 2.),
+            );
+            let handle_right_rect =
+                SkRect::from_point_and_size(handle_right_point, (size, size));
+
+            let sk_mpos = SkPoint::new(meta.position.0 as f32, meta.position.1 as f32);
+
+            if handle_left_rect.contains(sk_mpos) {
+                return Some((contour_idx, vws_handle_idx, WhichHandle::A));
+            } else if handle_right_rect.contains(sk_mpos) {
+                return Some((contour_idx, vws_handle_idx, WhichHandle::B));
+            }
+        }
+    }
+
+    None
 }

--- a/src/user_interface/gui/layer_list.rs
+++ b/src/user_interface/gui/layer_list.rs
@@ -98,7 +98,7 @@ pub fn build_and_check_layer_list(v: &mut Editor, i: &mut Interface, ui: &imgui:
             v.set_active_layer(layer);
 
             v.begin_modification("Toggled layer visibility.");
-            v.with_active_layer_mut(|layer| layer.visible = !layer.visible);
+            v.get_active_layer_mut().visible = !v.get_active_layer_ref().visible;
             v.end_modification();
 
             v.set_active_layer(active_layer);
@@ -118,7 +118,7 @@ pub fn build_and_check_layer_list(v: &mut Editor, i: &mut Interface, ui: &imgui:
                     editor.set_active_layer(layer);
 
                     editor.begin_modification("Renamed layer.");
-                    editor.with_active_layer_mut(|layer| layer.name = string.clone());
+                    editor.get_active_layer_mut().name = string;
                     editor.end_modification();
 
                     editor.set_active_layer(active_layer);
@@ -145,9 +145,7 @@ pub fn build_and_check_layer_list(v: &mut Editor, i: &mut Interface, ui: &imgui:
             let active_layer = v.get_active_layer();
             v.set_active_layer(layer);
             v.begin_modification("Changed layer operation.");
-            v.with_active_layer_mut(|layer| {
-                layer.operation = None;
-            });
+            v.get_active_layer_mut().operation = None;
             v.end_modification();
             v.set_active_layer(active_layer);
         }
@@ -165,9 +163,7 @@ pub fn build_and_check_layer_list(v: &mut Editor, i: &mut Interface, ui: &imgui:
             let active_layer = v.get_active_layer();
             v.set_active_layer(layer);
             v.begin_modification("Changed layer operation.");
-            v.with_active_layer_mut(|layer| {
-                layer.operation = new_operation.clone();
-            });
+            v.get_active_layer_mut().operation = new_operation;
             v.end_modification();
             v.set_active_layer(active_layer);
         }
@@ -196,7 +192,7 @@ pub fn build_and_check_layer_list(v: &mut Editor, i: &mut Interface, ui: &imgui:
                         editor.set_active_layer(layer);
 
                         editor.begin_modification("Changed layer color.");
-                        editor.with_active_layer_mut(|layer| layer.color = color.map(|c| c.into()));
+                        editor.get_active_layer_mut().color = color.map(|c| c.into());
                         editor.end_modification();
 
                         editor.set_active_layer(active_layer);


### PR DESCRIPTION
(This PR is by @MatthewBlanchard.)

* Replaces the `Editor::with_active_layer` family of functions with a new `Editor::get_active_layer` family of functions.
* Removes now unused `Editor` glyph editing API's.