### PR TITLE
Add Nix flake support

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+if has nix; then
+  use nix
+fi

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,143 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1668681692,
+        "narHash": "sha256-Ht91NGdewz8IQLtWZ9LCeNXMSXHUss+9COoqu6JLmXU=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "009399224d5e398d03b22badca40a37ac85412a1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "naersk": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1671096816,
+        "narHash": "sha256-ezQCsNgmpUHdZANDCILm3RvtO1xH8uujk/+EqNvzIOg=",
+        "owner": "nix-community",
+        "repo": "naersk",
+        "rev": "d998160d6a076cfe8f9741e56aeec7e267e3e114",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1669867399,
+        "narHash": "sha256-Z8RXSFYOsIsTG96ROKtV0eZ8Q7u4irFWm6ELqfw7mT8=",
+        "path": "/nix/store/dlvqwbipm0nj3h119hiyjqjj6awsc58z-source",
+        "rev": "38e591dd05ffc8bdf79dc752ba78b05e370416fa",
+        "type": "path"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1671813978,
+        "narHash": "sha256-oo4we+9IO1D+QS1mOSNh08l9ABDPWLyqvNC0DD0QtZM=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "79e63f30ed2ff36cd0d9c2f7dadae5925c1a65db",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "release-22.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1665296151,
+        "narHash": "sha256-uOB0oxqxN9K7XGF1hcnY+PQnlQJ+3bP2vCn/+Ru/bbc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "14ccaaedd95a488dd7ae142757884d8e125b3363",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "naersk": "naersk",
+        "nixpkgs": "nixpkgs_2",
+        "rust-overlay": "rust-overlay",
+        "utils": "utils"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs_3"
+      },
+      "locked": {
+        "lastModified": 1671848331,
+        "narHash": "sha256-KuNCxEZgzTmO3YpHvjNh9i+DUO6wSp6f1/3Qsczs5cw=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "631e692192eeeea85cdfb2a9dccbbfce543478b1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 let
   name = "MFEKglif";
-  description = "glyph editor";
+  description = "Glyph editor for the Modular Font Editor K project.";
 in {
   inherit name description;
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 let
-  name = "glif";
+  name = "MFEKglif";
   description = "glyph editor";
 in {
   inherit name description;

--- a/flake.nix
+++ b/flake.nix
@@ -32,13 +32,25 @@
             vulkan-loader
             vulkan-tools
         ];
+
       in rec {
         name = "MFEKglif";
         description = "Glyph editor for the Modular Font Editor K project.";
 
         defaultPackage = naersk-lib.buildPackage {
           pname = name;
+          inherit description;
+
           root = ./.;
+          buildInputs = with pkgs; [
+            pkg-config
+            glibc
+            gn
+            ninja
+          ];
+
+          LD_LIBRARY_PATH = "${pkgs.lib.makeLibraryPath (with pkgs; [ pkg-config ] ++ vulkan-dev)}:$LD_LIBRARY_PATH";
+          PKG_CONFIG_PATH = "${pkgs.glibc}:PKG_CONFIG_PATH";
         };
 
         devShells.default = pkgs.mkShell {

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,75 @@
+let
+  name = "glif";
+  description = "glyph editor";
+in {
+  inherit name description;
+
+  inputs = {
+    nixpkgs.url      = github:nixos/nixpkgs/release-22.05;
+    utils.url        = github:numtide/flake-utils;
+    rust-overlay.url = github:oxalica/rust-overlay;
+    naersk.url       = github:nix-community/naersk;
+
+    # Used for shell.nix
+    flake-compat = {
+      url = github:edolstra/flake-compat;
+      flake = false;
+    };
+  };
+
+  outputs = { self, nixpkgs, rust-overlay, utils, naersk, ... } @ inputs: let
+      overlays = [ rust-overlay.overlays.default ];
+      # Our supported systems are the same supported systems as the Rust binaries
+      systems = builtins.attrNames inputs.rust-overlay.packages;
+    in utils.lib.eachSystem systems (system:
+      let
+        pkgs = import nixpkgs { inherit overlays system; };
+        rust_channel = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain;
+        glif-test = pkgs.writeScriptBin "glif-test" ''
+          RUST_LOG=debug RUST_BACKTRACE=1 cargo run -- examples/Q_.glif
+        '';
+        naersk-lib = naersk.lib."${system}".override {
+          cargo = rust_channel;
+          rustc = rust_channel;
+        };
+        vulkan-dev = with pkgs; [
+            vulkan-headers
+            vulkan-loader
+            vulkan-tools
+        ];
+      in {
+        defaultPackage = naersk-lib.buildPackage {
+          pname = name;
+          root = ./.;
+        };
+
+        devShells.default = pkgs.mkShell {
+          inherit name description;
+          buildInputs = with pkgs; [
+            # all of rust unstable
+            rust_channel
+            rust-analyzer
+            cargo
+            lld
+            pkg-config
+            glibc
+            gtk3.dev
+            SDL2
+            glif-test
+          ] ++ vulkan-dev;
+
+          LD_LIBRARY_PATH = "${pkgs.lib.makeLibraryPath (with pkgs; [ pkg-config ] ++ vulkan-dev)}:$LD_LIBRARY_PATH";
+          PKG_CONFIG_PATH = "${pkgs.glibc}:PKG_CONFIG_PATH";
+
+          # for rust-analyzer; the target dir of the compiler for the project
+          OUT_DIR = "./target";
+          # don't warn for dead code, unused imports or unused variables
+          RUSTFLAGS = "-A dead_code -A unused_imports -A unused_variables";
+          # force cross compilation when there is potential for it
+          CARGO_FEATURE_FORCE_CROSS = "true";
+        };
+
+        # For compatibility with older versions of the `nix` binary
+        devShell = self.devShells.${system}.default;
+      });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,9 +1,4 @@
-let
-  name = "MFEKglif";
-  description = "Glyph editor for the Modular Font Editor K project.";
-in {
-  inherit name description;
-
+{
   inputs = {
     nixpkgs.url      = github:nixos/nixpkgs/release-22.05;
     utils.url        = github:numtide/flake-utils;
@@ -37,7 +32,10 @@ in {
             vulkan-loader
             vulkan-tools
         ];
-      in {
+      in rec {
+        name = "MFEKglif";
+        description = "Glyph editor for the Modular Font Editor K project.";
+
         defaultPackage = naersk-lib.buildPackage {
           pname = name;
           root = ./.;

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,12 @@
+(import
+  (
+    let
+      flake-compat = (builtins.fromJSON (builtins.readFile ./flake.lock)).nodes.flake-compat;
+    in
+      fetchTarball {
+        url = "https://github.com/edolstra/flake-compat/archive/${flake-compat.locked.rev}.tar.gz";
+        sha256 = flake-compat.locked.narHash;
+      }
+  )
+  {src = ./.;})
+.shellNix


### PR DESCRIPTION
This helps anyone who uses `NixOS` or `nix` get started with a development environment seamlessly. If someone has `nix` and `direnv` installed, upon entering this repository they'll have a development environment with the exact versions of rust and all of the system packages necessary to build the repo.

It:
- Exposes a development shell with all system and rust dependencies configured
- Adds a `glif-test` command adhering to the suggested `cargo run` command in the README for testing the package
-  Enables nix builds of the `glif` package, which can then be pulled into other packages

I put this together to get glif to run on my end; merge if others would use, OK to close if not.