### PR TITLE
Use toolchain file in Actions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,7 +34,6 @@ jobs:
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
           override: true
           components: clippy
       - name: Cache cargo builds
@@ -76,7 +75,6 @@ jobs:
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
           override: true
           components: rustfmt
       - name: Run rustfmt
@@ -94,7 +92,6 @@ jobs:
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
           override: true
       - name: Cache cargo builds
         uses: actions/cache@v2


### PR DESCRIPTION
Commit 071470a requires nightly compiler but only modify the `rust-toolchain` file. Newest [action-rs](https://github.com/actions-rs/toolchain#the-toolchain-file) use `rust-toolchain` file when no `toolchain` input is provided.