### PR TITLE
Fix crash bug in move_handle.rs

### DIFF
--- a/src/tool_behaviors/move_handle.rs
+++ b/src/tool_behaviors/move_handle.rs
@@ -66,7 +66,7 @@ impl MoveHandle {
                 follow = Follow::ForceLine;
             }
 
-            if point.get_handle(self.wh.opposite()).unwrap() == Handle::Colocated && follow == Follow::ForceLine {
+            if point.get_handle(self.wh.opposite()).is_some_and(|wh| wh == Handle::Colocated) && follow == Follow::ForceLine {
                 // If the opposite handle is colocated, force line crashes due to unwrapping a None value.
                 follow = Follow::No;
             }


### PR DESCRIPTION
I'm frankly not sure how I let this slip by in my initial testing. It will specifically crash if you try to place a quadratic or hyper curve without first placing a cubic curve...